### PR TITLE
correct color for bad sensors that are interpolated

### DIFF
--- a/auto_examples/plot_visualize_bad_epochs.html
+++ b/auto_examples/plot_visualize_bad_epochs.html
@@ -1330,7 +1330,7 @@ Repairing epochs: 100%|##########| 193/193 [00:05&lt;00:00, 32.19it/s][A[ADrop
 </pre></div>
 </div>
 <p>… and visualize the bad epochs and sensors. Bad sensors which have been
-interpolated are in blue. Bad sensors which are not interpolated are in red.
+interpolated are in grey. Bad sensors which are not interpolated are in red.
 Bad trials are also in red.</p>
 <div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="n">scalings</span> <span class="o">=</span> <span class="nb">dict</span><span class="p">(</span><span class="n">eeg</span><span class="o">=</span><span class="mf">40e-6</span><span class="p">)</span>
 <span class="n">reject_log</span><span class="o">.</span><span class="n">plot_epochs</span><span class="p">(</span><span class="n">this_epoch</span><span class="p">,</span> <span class="n">scalings</span><span class="o">=</span><span class="n">scalings</span><span class="p">)</span>


### PR DESCRIPTION
As a double check, the color specified [here](https://github.com/autoreject/autoreject/blob/c3f5a8186ed15fd7e16a4f44d36a3f22390ee2c4/autoreject/autoreject.py#L1371) is 0.6,0.6,0.6 which is grey